### PR TITLE
Fallback for the "Take Action" page

### DIFF
--- a/sms_counter.js
+++ b/sms_counter.js
@@ -24,6 +24,10 @@ javascript: (function () {
   // Otherwise add the message counter element to the page
   var gyrContainer = document.querySelector( '.text-message-form .form-group' );
   console.log(textarea);
+  if (gyrContainer === null) {
+    // Could be on the "Take Action" page
+    gyrContainer = document.querySelector( '#hub_take_action_form_message_body' ).parentElement;
+  }
 
   var countContainer = document.createElement( 'div' );
   countContainer.id = 'gyr_message_counter';
@@ -67,6 +71,10 @@ javascript: (function () {
   }
 
   var textarea = document.getElementById( 'outgoing_text_message_body' );
+  if (textarea === null) {
+    // Could be on the "Take Action" page
+    textarea = document.getElementById( 'hub_take_action_form_message_body' );
+  }
   textarea.addEventListener( 'input', gyr_calc_num_messages );
 
 


### PR DESCRIPTION
Works great on the message page, but I usually send initial messages to clients on the "Take Action" page, when requesting information. This adds a fallback to also add the count there.

(screenshot from Demo Hub)

![Screenshot from 2021-02-19 23-29-39](https://user-images.githubusercontent.com/6252212/108583831-6669a980-730a-11eb-8998-73d52ca49aa9.png)
