### PR TITLE
Use alternate counting: show characters til next message

### DIFF
--- a/sms_counter.js
+++ b/sms_counter.js
@@ -59,11 +59,11 @@ javascript: (function () {
     var num = event.target.value.length;
     numCharsNode.innerText = num;
 
+    msg_length = 160;
     if ( num > 160 ) {
-      numMsgsNode.innerText = Math.round( (num/147 ) * 100 ) / 100;
-    } else {
-      numMsgsNode.innerText =  Math.round( (num/160 ) * 100 ) / 100;;
+      msg_length = 147;
     }
+    numMsgsNode.innerText = `${Math.ceil(num / msg_length)} (${msg_length - (num % msg_length)} characters til next message)`
   }
 
   var textarea = document.getElementById( 'outgoing_text_message_body' );


### PR DESCRIPTION
This one's more debatable / optional. I'm used to SMS apps on my phone displaying the number of characters until the next message instead of sticking with a decimal display. IMO it's a little easier to understand, but it is pretty different. Up to you if we want to merge. 

Example below:
![Screenshot from 2021-02-19 23-31-16](https://user-images.githubusercontent.com/6252212/108583895-e5f77880-730a-11eb-9311-57a6cbd3fbd4.png)
